### PR TITLE
Fix: installation doesn't work if React Native isn't the first dependency listed in package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,11 +13,9 @@ function run() {
     console.error('package.json couldn\'t be found, maybe `%s` is not the root of project directory', process.cwd());
     process.exit(1);
   } finally {
-    var react = Object.keys(packages.dependencies).map(function (val) {
-      if (val === 'react-native') return true;
-    });
+    var hasReactNative = packages.dependencies.hasOwnProperty('react-native');
 
-    if (react[0]) {
+    if (hasReactNative) {
       writing(source, target);
     } else {
       console.error('react-native dependencies couldn\'t be found, maybe `%s` is not the root of react-native project directory', process.cwd());


### PR DESCRIPTION
Before this change, it only works if react-native is the first dependency listed in package.json and fails with `react-native dependencies couldn't be found, maybe`&lt;folder>`is not the root of react-native project directory` otherwise.

This change makes sure it will also work if it's listed further on in the list of dependencies.
